### PR TITLE
 !!! TASK: Use Neos FusionView, rename TypoScript to Fusion, update code style

### DIFF
--- a/Classes/Controller/RenderingController.php
+++ b/Classes/Controller/RenderingController.php
@@ -1,20 +1,20 @@
 <?php
 namespace Ttree\OutOfBandRendering\Controller;
 
-use Ttree\OutOfBandRendering\Factory\PresetDefinitionFactory;
+use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Exception;
 use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Flow\Property\PropertyMapper;
 use Neos\Neos\Controller\Exception\NodeNotFoundException;
-use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Neos\View\FusionView;
+use Ttree\OutOfBandRendering\Factory\PresetDefinitionFactory;
 
 /**
  * Suggest Controller
  */
-class RenderingController extends ActionController {
-
+class RenderingController extends ActionController
+{
     /**
      * @var FusionView
      */
@@ -42,15 +42,16 @@ class RenderingController extends ActionController {
      * @param string $preset
      * @throws Exception
      */
-    public function showAction($node, $preset) {
+    public function showAction(string $node, string $preset)
+    {
         /** @var NodeInterface $node */
         $node = $this->propertyMapper->convert($node, NodeInterface::class);
-        if ($node === NULL) {
+        if ($node === null) {
             throw new NodeNotFoundException('The requested node does not exist or isn\'t accessible to the current user', 1442327533);
         }
         $this->view->assign('value', $node);
         $presetDefinition = $this->presetDefinitionFactory->create($preset, $node);
-        $this->view->setFusionPath($presetDefinition->getTypoScriptPath($node));
+        $this->view->setFusionPath($presetDefinition->getFusionPath($node));
     }
 
 }

--- a/Classes/Controller/RenderingController.php
+++ b/Classes/Controller/RenderingController.php
@@ -8,7 +8,7 @@ use Neos\Flow\Mvc\Controller\ActionController;
 use Neos\Flow\Property\PropertyMapper;
 use Neos\Neos\Controller\Exception\NodeNotFoundException;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
-use Neos\Fusion\View\FusionView;
+use Neos\Neos\View\FusionView;
 
 /**
  * Suggest Controller

--- a/Classes/Domain/Model/AbstractPresetDefinition.php
+++ b/Classes/Domain/Model/AbstractPresetDefinition.php
@@ -6,8 +6,8 @@ use Neos\ContentRepository\Domain\Model\NodeInterface;
 /**
  * Abstract Preset Definition
  */
-abstract class AbstractPresetDefinition implements PresetDefinitionInterface {
-
+abstract class AbstractPresetDefinition implements PresetDefinitionInterface
+{
     /**
      * {@inheritdoc}
      *
@@ -20,7 +20,8 @@ abstract class AbstractPresetDefinition implements PresetDefinitionInterface {
      *
      * @return integer
      */
-    public function getName() {
+    public function getName(): string
+    {
         $calledClassName = explode('\\', get_called_class());
         return strtolower(trim(preg_replace('/([A-Z])/', '-$1', str_replace('PresetDefinition', '', array_pop($calledClassName))), '-'));
     }
@@ -28,9 +29,10 @@ abstract class AbstractPresetDefinition implements PresetDefinitionInterface {
     /**
      * {@inheritdoc}
      *
-     * @return integer
+     * @return int
      */
-    public function getPriority() {
+    public function getPriority(): int
+    {
         return $this->priority;
     }
 
@@ -38,10 +40,10 @@ abstract class AbstractPresetDefinition implements PresetDefinitionInterface {
      * {@inheritdoc}
      *
      * @param NodeInterface $node
-     * @return boolean
+     * @return bool
      */
-    public function canHandle(NodeInterface $node) {
-        return TRUE;
+    public function canHandle(NodeInterface $node): bool
+    {
+        return true;
     }
-
 }

--- a/Classes/Domain/Model/GenericPresetDefinition.php
+++ b/Classes/Domain/Model/GenericPresetDefinition.php
@@ -6,8 +6,8 @@ use Neos\ContentRepository\Domain\Model\NodeInterface;
 /**
  * Abstract Preset Definition
  */
-class GenericPresetDefinition extends AbstractPresetDefinition {
-
+class GenericPresetDefinition extends AbstractPresetDefinition
+{
     /**
      * @var string
      */
@@ -22,25 +22,27 @@ class GenericPresetDefinition extends AbstractPresetDefinition {
      * @param string $name
      * @param array $configuration
      */
-    public function __construct($name, array $configuration)
+    public function __construct(string $name, array $configuration)
     {
         $this->name = (string)$name;
         $this->path = (string)$configuration['path'];
     }
 
     /**
-     * @return integer
+     * @return string
      */
-    public function getName() {
+    public function getName(): string
+    {
         return $this->name;
     }
 
     /**
      * {@inheritdoc}
      *
-     * @return integer
+     * @return int
      */
-    public function getPriority() {
+    public function getPriority(): int
+    {
         return $this->priority;
     }
 
@@ -48,9 +50,10 @@ class GenericPresetDefinition extends AbstractPresetDefinition {
      * {@inheritdoc}
      *
      * @param NodeInterface $node
-     * @return boolean
+     * @return bool
      */
-    public function canHandle(NodeInterface $node) {
+    public function canHandle(NodeInterface $node): bool
+    {
         return true;
     }
 
@@ -58,7 +61,7 @@ class GenericPresetDefinition extends AbstractPresetDefinition {
      * @param NodeInterface $node
      * @return string
      */
-    public function getTypoScriptPath(NodeInterface $node)
+    public function getFusionPath(NodeInterface $node): string
     {
         return $this->path;
     }

--- a/Classes/Domain/Model/PresetDefinitionInterface.php
+++ b/Classes/Domain/Model/PresetDefinitionInterface.php
@@ -6,35 +6,34 @@ use Neos\ContentRepository\Domain\Model\NodeInterface;
 /**
  * Preset Definition Interface
  */
-interface PresetDefinitionInterface {
-
+interface PresetDefinitionInterface
+{
     /**
      * Return the priority of this PresetDefinition. PresetDefinitions with a high priority are chosen before low priority.
      *
-     * @return integer
+     * @return int
      * @api
      */
-    public function getPriority();
+    public function getPriority(): int;
 
     /**
      * @return string
      */
-    public function getName();
+    public function getName(): string;
 
     /**
      * Here, the PresetDefinition can do some additional runtime checks to see whether
      * it can handle the given node.
      *
      * @param NodeInterface $node
-     * @return boolean TRUE
+     * @return bool TRUE
      * @api
      */
-    public function canHandle(NodeInterface $node);
+    public function canHandle(NodeInterface $node): bool;
 
     /**
      * @param NodeInterface $node
      * @return string
      */
-    public function getTypoScriptPath(NodeInterface $node);
-
+    public function getFusionPath(NodeInterface $node): string;
 }

--- a/Classes/Exception/DuplicatePresetDefinitionException.php
+++ b/Classes/Exception/DuplicatePresetDefinitionException.php
@@ -4,6 +4,6 @@ namespace Ttree\OutOfBandRendering\Exception;
 /**
  * A Duplicate Preset Definition Exception
  */
-class DuplicatePresetDefinitionException extends Exception {
-
+class DuplicatePresetDefinitionException extends Exception
+{
 }

--- a/Classes/Exception/Exception.php
+++ b/Classes/Exception/Exception.php
@@ -1,10 +1,9 @@
 <?php
 namespace Ttree\OutOfBandRendering\Exception;
 
-
 /**
  * A generic OutOfBandRendering exception
  */
-class Exception extends \Neos\Neos\Exception {
-
+class Exception extends \Neos\Neos\Exception
+{
 }

--- a/Classes/Exception/PresetNotFoundException.php
+++ b/Classes/Exception/PresetNotFoundException.php
@@ -4,6 +4,6 @@ namespace Ttree\OutOfBandRendering\Exception;
 /**
  * A Preset Not Found Exception exception
  */
-class PresetNotFoundException extends Exception {
-
+class PresetNotFoundException extends Exception
+{
 }

--- a/Classes/Factory/PresetDefinitionFactory.php
+++ b/Classes/Factory/PresetDefinitionFactory.php
@@ -1,14 +1,14 @@
 <?php
 namespace Ttree\OutOfBandRendering\Factory;
 
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+use Neos\Flow\Reflection\ReflectionService;
 use Ttree\OutOfBandRendering\Domain\Model\GenericPresetDefinition;
 use Ttree\OutOfBandRendering\Domain\Model\PresetDefinitionInterface;
 use Ttree\OutOfBandRendering\Exception\DuplicatePresetDefinitionException;
 use Ttree\OutOfBandRendering\Exception\PresetNotFoundException;
-use Neos\Flow\Annotations as Flow;
-use Neos\Flow\ObjectManagement\ObjectManagerInterface;
-use Neos\ContentRepository\Domain\Model\NodeInterface;
-use Neos\Flow\Reflection\ReflectionService;
 
 /**
  * Preset Definition Factory
@@ -16,7 +16,8 @@ use Neos\Flow\Reflection\ReflectionService;
  * @Flow\Scope("singleton")
  * @api
  */
-class PresetDefinitionFactory {
+class PresetDefinitionFactory
+{
 
     const PRESET_DEFINITION_INTERFACE = PresetDefinitionInterface::class;
 
@@ -40,15 +41,17 @@ class PresetDefinitionFactory {
     /**
      * @var boolean
      */
-    protected $initialized = FALSE;
+    protected $initialized = false;
 
     /**
      * @param $presetName
      * @param NodeInterface $node
      * @return PresetDefinitionInterface
      * @throws PresetNotFoundException
+     * @throws DuplicatePresetDefinitionException
      */
-    public function create($presetName, NodeInterface $node) {
+    public function create(string $presetName, NodeInterface $node): PresetDefinitionInterface
+    {
         $this->initialize();
         if (!isset($this->presetDefinitions[$presetName]) && !isset($this->staticPresets[$presetName])) {
             throw new PresetNotFoundException(sprintf('Preset "%s" not found', $presetName), 1442471214);
@@ -72,7 +75,8 @@ class PresetDefinitionFactory {
      * @return array Array of preset definition implementations
      * @Flow\CompileStatic
      */
-    static public function getPresetDefinitionImplementationClassNames($objectManager) {
+    static public function getPresetDefinitionImplementationClassNames(ObjectManagerInterface $objectManager): array
+    {
         $reflectionService = $objectManager->get(ReflectionService::class);
         return $reflectionService->getAllImplementationClassNamesForInterface(self::PRESET_DEFINITION_INTERFACE);
     }
@@ -81,8 +85,9 @@ class PresetDefinitionFactory {
      * @return void
      * @throws DuplicatePresetDefinitionException
      */
-    protected function initialize() {
-        if ($this->initialized === TRUE) {
+    protected function initialize(): void
+    {
+        if ($this->initialized === true) {
             return;
         }
         $classNames = static::getPresetDefinitionImplementationClassNames($this->objectManager);
@@ -97,7 +102,6 @@ class PresetDefinitionFactory {
             }
             $this->presetDefinitions[$presetDefinition->getName()][$presetDefinition->getPriority()] = $presetDefinition;
         }
-        $this->initialized = TRUE;
+        $this->initialized = true;
     }
-
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# TypoScript Out of Band rendering helpers
+# Fusion Out of Band rendering helpers
 
-This package provide some helpers to work with TypoScript Out of Band rendering in Neos CMS
+This package provide some helpers to work with Fusion Out of Band rendering in Neos CMS
 
 **Package under development, API can change at any time**
 
@@ -26,26 +26,26 @@ Check the [Routes.yaml](Configuration/Routes.yaml) in this package, if you need 
 The endpoint require two parameters:
 
 - **node**: the full node path of the rendering node
-- **preset**: the preset name, check bellow for informations about Presets
+- **preset**: the preset name, check below for information about Presets
 
 You can create preset in two different ways, static presets in ```Settings.yaml``` and dynamic presets with your
-own PHP implementation. A preset is mainly used to limit the TypoScript path that can be rendered out of band.
+own PHP implementation. A preset is mainly used to limit the Fusion path that can be rendered out of band.
 
 ### Static Preset
 
-To use static preset, just writte something like this in your ```Settings.yaml```: 
+To use static preset, just write something like this in your ```Settings.yaml```: 
 
     Ttree:
       OutOfBandRendering:
         presets:
           'marketplace:version':
-            path: 'root<Neos.Fusion:Case>/neosMarketPlaceDocument<Neos.Fusion:Matcher>/element<Neos.MarketPlace:Package.Document>/body<Neos.Fusion:Template>/content/main<Neos.Fusion:Array>/package<Neos.MarketPlace:Package>/versions<Neos.MarketPlace:VersionPreview>'
+            path: 'root<Neos.Fusion:Case>/neosMarketPlaceDocument<Neos.Fusion:Matcher>/element<Neos.MarketPlace:Package>/body<Neos.Fusion:Template>/content/main<Neos.Fusion:Array>/package<Neos.MarketPlace:Package>/versions<Neos.MarketPlace:VersionPreview>'
 
-The key ```marketplace:version``` is your preset name, and the path the allowed TypoScript path to be rendered.
+The key ```marketplace:version``` is your preset name, and the path the allowed Fusion path to be rendered.
 
 ### Dynamic Preset
 
-A dynamic preset is more flexible and allow you to generate the TypoScript path dynamically based on the given node.
+A dynamic preset is more flexible and allow you to generate the Fusion path dynamically based on the given node.
 
 You need a ```PresetDefintion``` object, the easy way is to extend the ```AbstractPresetDefinition``` like this:
 
@@ -72,7 +72,7 @@ The ```PresetDefinitionInterface``` force you to defined the following methods:
 - **PresetDefinitionInterface::getPriority**: Return an integer to define the preset priority (higher has more priority, like in the Flow Framework PropertyMapper
 - **PresetDefinitionInterface::getName**: Return the name of the preset (used in the endpoint URL)
 - **PresetDefinitionInterface::canHandle**: Receive the current document node as argument, and allow you to add more logic to decide if a preset can handle the given node
-- **PresetDefinitionInterface::getTypoScriptPath**: Receive the current document node as argument, must return the TypoScript path to render
+- **PresetDefinitionInterface::getTypoScriptPath**: Receive the current document node as argument, must return the Fusion path to render
 
 ## What's next ?
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ class CustomPresetPresetDefinition extends AbstractPresetDefinition  {
      * @param NodeInterface $node
      * @return string
      */
-    public function getTypoScriptPath(NodeInterface $node) {
+    public function getFusionPath(NodeInterface $node) {
         return 'page<Ttree.ArchitectesCh:DefaultPage>/body<Neos.Fusion:Template>/content/main<Neos.Neos:PrimaryContent>/enterpriseProfile<Neos.Fusion:Matcher>/element<Ttree.ArchitectesCh:EnterpriseProfile>/reportSection<Ttree.ArchitectesCh:EnterpriseProfileSection>/content<Ttree.ArchitectesCh:ReportMenu>';
     }
 }
@@ -72,7 +72,7 @@ The ```PresetDefinitionInterface``` force you to defined the following methods:
 - **PresetDefinitionInterface::getPriority**: Return an integer to define the preset priority (higher has more priority, like in the Flow Framework PropertyMapper
 - **PresetDefinitionInterface::getName**: Return the name of the preset (used in the endpoint URL)
 - **PresetDefinitionInterface::canHandle**: Receive the current document node as argument, and allow you to add more logic to decide if a preset can handle the given node
-- **PresetDefinitionInterface::getTypoScriptPath**: Receive the current document node as argument, must return the Fusion path to render
+- **PresetDefinitionInterface::getFusionPath**: Receive the current document node as argument, must return the Fusion path to render
 
 ## What's next ?
 


### PR DESCRIPTION
Marked as breaking, since the `PresetDefinitionInterface` has changed.
You need to add type declarations and change the name of the method
`getTypoScriptPath` to `getFusionPath`.